### PR TITLE
test invalid chars in string

### DIFF
--- a/tests/testthat/test-CRAN-all.R
+++ b/tests/testthat/test-CRAN-all.R
@@ -171,11 +171,11 @@ test_engines("error for capture all regex with literal groups, no match", {
 
 test_engines("before_pattern on invalid R string should work", {
   link_pattern <- list(
-  "\\[",
-  title=".*?",
-  "\\]\\(",
-  url="http.*?",
-  "\\)")
+    "\\[",
+    title=".*?",
+    "\\]\\(",
+    url="http.*?",
+    "\\)")
   before_pattern <- list(
     before="(?s).*?",
     nc::alternatives(

--- a/tests/testthat/test-CRAN-all.R
+++ b/tests/testthat/test-CRAN-all.R
@@ -168,3 +168,25 @@ test_engines("error for capture all regex with literal groups, no match", {
     nc::capture_all_str("alias(es)", foo="alias(es)")
   }, "regex contains more groups than names; please remove literal groups (parentheses) from the regex pattern, and use named arguments in R code instead", fixed=TRUE)
 })
+
+test_engines("before_pattern on invalid R string should work", {
+  link_pattern <- list(
+  "\\[",
+  title=".*?",
+  "\\]\\(",
+  url="http.*?",
+  "\\)")
+  before_pattern <- list(
+    before="(?s).*?",
+    nc::alternatives(
+      link=link_pattern,
+      "$"))
+  base_names <- c("valid.R", "invalid.R", "vignette.Rmd")
+  input_files <- system.file(
+    package="nc", "extdata", base_names)
+  match_dt_list <- list()
+  for(f in input_files){
+    match_dt_list[[basename(f)]] <- nc::capture_all_str(f, before_pattern)
+  }
+  expect_identical(names(match_dt_list), base_names)
+})


### PR DESCRIPTION
on CI we have
```
══ Failed tests ════════════════════════════════════════════════════════════════
── Failure ('test-CRAN-all.R:191:3'): RE2 before_pattern on invalid R string should work ──
Expected `names(match_dt_list)` to be identical to `base_names`.
Differences:
Lengths differ: 1 is not 3
── Failure ('test-CRAN-all.R:191:3'): ICU before_pattern on invalid R string should work ──
Expected `names(match_dt_list)` to be identical to `base_names`.
Differences:
Lengths differ: 1 is not 3
── Failure ('test-CRAN-all.R:191:3'): PCRE before_pattern on invalid R string should work ──
Expected `names(match_dt_list)` to be identical to `base_names`.
Differences:
Lengths differ: 1 is not 3

[ FAIL 3 | WARN 0 | SKIP 0 | PASS 702 ]
```
but locally we have
```
── Failed tests ────────────────────────────────────────────────────────────────
Error (test-CRAN-all.R:189:5): PCRE before_pattern on invalid R string should work
Error in `dimnames(x) <- dn`: length of 'dimnames' [2] not equal to array extent
Backtrace:
    ▆
 1. └─nc::capture_all_str(f, before_pattern) at test-CRAN-all.R:189:5
 2.   └─nc:::apply_type_funs(group.mat, L[["fun.list"]]) at nc/R/capture_all_str.R:67:3
 3.     └─base::`colnames<-`(`*tmp*`, value = names(fun.list)) at nc/R/apply_type_funs.R:16:3

[ FAIL 1 | WARN 1 | SKIP 0 | PASS 704 ]
```
since PCRE does not work but the other engines do, this seems to be an issue in base R.
gregexpr() should return attributes, even when there is no match in bad string.
